### PR TITLE
fix: show all planets

### DIFF
--- a/arturito/src/components/PlanetsSection/index.tsx
+++ b/arturito/src/components/PlanetsSection/index.tsx
@@ -43,7 +43,7 @@ const Planets = () => {
 
   return (
     <div>
-      <Table columns={columns} data={data.results.slice(0, 3)} /* :D */ />
+      <Table columns={columns} data={data.results} /* :D */ />
     </div>
   );
 };


### PR DESCRIPTION
The slice function was preventing all the planets from being shown